### PR TITLE
Add unit testing for Wav.Net

### DIFF
--- a/Wav.Net.Tests/Properties/AssemblyInfo.cs
+++ b/Wav.Net.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Wav.Net.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("ArcticEcho + ProgramFOX")]
+[assembly: AssemblyProduct("Wav.Net.Tests")]
+[assembly: AssemblyCopyright("Copyright © ArcticEcho + ProgramFOX 2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("5d3f92ab-c503-41d6-98cc-10e9de547d4a")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Wav.Net.Tests/UnitTesting/TestMath.cs
+++ b/Wav.Net.Tests/UnitTesting/TestMath.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using WavMath = WavDotNet.Tools.Math;
+
+namespace WavDotNet.Tests.UnitTesting
+{
+    [TestClass]
+    public class TestMath
+    {
+        [TestMethod]
+        public void TestToDecibels()
+        {
+            Assert.AreEqual(WavMath.ToDecibels(10D), 20);
+            Assert.AreEqual(WavMath.ToDecibels(10F), 20);
+            Assert.AreEqual(WavMath.ToDecibels(100D), 40);
+            Assert.AreEqual(WavMath.ToDecibels(100F), 40);
+        }
+
+        [TestMethod]
+        public void TestToAmplitude()
+        {
+            Assert.AreEqual(WavMath.ToAmplitude(100D), 100000);
+            Assert.AreEqual(WavMath.ToAmplitude(100F), 100000);
+        }
+    }
+}

--- a/Wav.Net.Tests/Wav.Net.Tests.csproj
+++ b/Wav.Net.Tests/Wav.Net.Tests.csproj
@@ -1,0 +1,68 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{80EA78B1-9FDD-4E7A-89C1-749A5A7C7F83}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>WavDotNet.Tests</RootNamespace>
+    <AssemblyName>WavDotNet.Tests</AssemblyName>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UnitTesting\TestMath.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Wav.Net\Wav.Net.csproj">
+      <Project>{05bb732f-9a16-4c82-a293-9d7144997242}</Project>
+      <Name>Wav.Net</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Wav.Net/Wav.Net.sln
+++ b/Wav.Net/Wav.Net.sln
@@ -1,7 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wav.Net", "Wav.Net.csproj", "{05BB732F-9A16-4C82-A293-9D7144997242}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wav.Net.Tests", "..\Wav.Net.Tests\Wav.Net.Tests.csproj", "{80EA78B1-9FDD-4E7A-89C1-749A5A7C7F83}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -13,6 +17,10 @@ Global
 		{05BB732F-9A16-4C82-A293-9D7144997242}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{05BB732F-9A16-4C82-A293-9D7144997242}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{05BB732F-9A16-4C82-A293-9D7144997242}.Release|Any CPU.Build.0 = Release|Any CPU
+		{80EA78B1-9FDD-4E7A-89C1-749A5A7C7F83}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{80EA78B1-9FDD-4E7A-89C1-749A5A7C7F83}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{80EA78B1-9FDD-4E7A-89C1-749A5A7C7F83}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{80EA78B1-9FDD-4E7A-89C1-749A5A7C7F83}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This commit adds a small amount of unit tests for Wav.Net: it tests
ToDecibels and ToAmplitude of the Math class. Travis integration is not
implemented yet.
